### PR TITLE
Preserve user-specified dock icon after activity notification.

### DIFF
--- a/Source/Controllers/AppController.h
+++ b/Source/Controllers/AppController.h
@@ -205,7 +205,8 @@ extern char **argv;
 - (void)channelListColorChanged:(NSNotification *)note;
 - (void)awakeFromNib;
 
-- (void)setIcon:(NSImage *)icon;
+- (void)setNotificationIcon;
+- (void)setDefaultIcon;
 - (void)presentUnexpectedEvent:(NSString *)description;
 - (NSInteger)presentCertificateTrustPanel:(SecTrustRef)trust;
 

--- a/Source/Controllers/AppController.h
+++ b/Source/Controllers/AppController.h
@@ -94,8 +94,6 @@ extern char **argv;
 	bool quitting;
 	bool sleeping;
 	NSImage *iconOnPriv;
-	NSImage *defaultIcon;
-	NSImage *currentIcon;
 	int hilightChannels;
 	NSString **shortcutCommands;
   

--- a/Source/Controllers/AppController.m
+++ b/Source/Controllers/AppController.m
@@ -994,18 +994,12 @@ static char *kMIJoinChannelAlertKey = "kMIJoinChannelAlertKey";
 //-------------------------------------------------------------------
 - (void)setNotificationIcon
 {
-  if (currentIcon != iconOnPriv) {
-    [NSApp setApplicationIconImage:iconOnPriv];
-    currentIcon = iconOnPriv;
-  }
+  [NSApp setApplicationIconImage:iconOnPriv];
 }
 
 - (void)setDefaultIcon
 {
-  if (currentIcon != defaultIcon) {
-    [NSApp setApplicationIconImage:defaultIcon];
-    currentIcon = defaultIcon;
-  }
+  [NSApp setApplicationIconImage:nil];
 }
 
 //-------------------------------------------------------------------
@@ -1731,7 +1725,6 @@ static char *kMIJoinChannelAlertKey = "kMIJoinChannelAlertKey";
   [self checkAndConvertOldShortcuts];
   [self buildShortcutsMenu];
   
-  currentIcon = defaultIcon = [[NSApp applicationIconImage] copy];
   iconOnPriv = [[NSImage alloc] initWithContentsOfFile:[[[NSBundle mainBundle] bundlePath] stringByAppendingString:@"/Contents/Resources/MacIrssi-Alert.png"]];
   if (!iconOnPriv) {
     NSLog(@"Can't load 'icon-dot' image!");

--- a/Source/Controllers/AppController.m
+++ b/Source/Controllers/AppController.m
@@ -430,13 +430,13 @@ static char *kMIJoinChannelAlertKey = "kMIJoinChannelAlertKey";
   if (wind->data_level > 2 && old <= 2) {    
     /* Notify user by changing icon */
     hilightChannels++;
-    [self setIcon:iconOnPriv];
+    [self setNotificationIcon];
   }
   else if (wind->data_level == 0 && old > 2) {
     /* Check if all notified channels have been visited */
     hilightChannels--;
     if (hilightChannels == 0)
-      [self setIcon:defaultIcon];
+      [self setDefaultIcon];
   }
 }
 
@@ -989,18 +989,20 @@ static char *kMIJoinChannelAlertKey = "kMIJoinChannelAlertKey";
 }
 
 //-------------------------------------------------------------------
-// setIcon:
-// Sets the icon in the dock to a specific image.
-//
-// "icon" - The image
+// setNotificationIcon, setDefaultIcon
+// Changes the icon in the dock.
 //-------------------------------------------------------------------
-- (void)setIcon:(NSImage *)icon
+- (void)setNotificationIcon
 {
-  if (icon == iconOnPriv && currentIcon != iconOnPriv) {
+  if (currentIcon != iconOnPriv) {
     [NSApp setApplicationIconImage:iconOnPriv];
     currentIcon = iconOnPriv;
   }
-  else if (icon == defaultIcon && currentIcon != defaultIcon) {
+}
+
+- (void)setDefaultIcon
+{
+  if (currentIcon != defaultIcon) {
     [NSApp setApplicationIconImage:defaultIcon];
     currentIcon = defaultIcon;
   }
@@ -1488,7 +1490,7 @@ static char *kMIJoinChannelAlertKey = "kMIJoinChannelAlertKey";
    app was inactive while no other channel needs notification, then we
    must revert icon to normal */
   if (hilightChannels == 0)
-    [self setIcon:defaultIcon];
+    [self setDefaultIcon];
   
   [channelBar setNeedsDisplay:YES];
   

--- a/Source/DebugController.m
+++ b/Source/DebugController.m
@@ -142,7 +142,16 @@ static int urlTestLinesCount = 34;
     
     NSMenuItem *simulateDisconnection = [[[NSMenuItem alloc] initWithTitle:@"Simulate Disconnection" target:self action:@selector(simiulateDisconnection:) keyEquivalent:@""] autorelease];
     [disconnectionMenu addItem:simulateDisconnection];    
-    
+
+    NSMenuItem *activityNotificationItem = [[[NSMenuItem alloc] initWithTitle:@"Activity Notification Icon" action:nil keyEquivalent:@""] autorelease];
+    [debugMenu addItem:activityNotificationItem];
+    NSMenu *activityNotificationMenu = [[[NSMenu alloc] init] autorelease];
+    NSMenuItem *activityNotificationTriggerItem = [[[NSMenuItem alloc] initWithTitle:@"Set Notification Icon" target:appController action:@selector(setNotificationIcon) keyEquivalent:@""] autorelease];
+    NSMenuItem *activityNotificationClearItem = [[[NSMenuItem alloc] initWithTitle:@"Set Default Icon" target:appController action:@selector(setDefaultIcon) keyEquivalent:@""] autorelease];
+    [activityNotificationMenu addItem:activityNotificationTriggerItem];
+    [activityNotificationMenu addItem:activityNotificationClearItem];
+    [activityNotificationItem setSubmenu:activityNotificationMenu];
+
     NSMenuItem *forceScrollToBottom = [[NSMenuItem alloc] initWithTitle:@"Force Scroll to Bottom" target:self action:@selector(forceScrollToBottom:) keyEquivalent:@""];
     [debugMenu addItem:forceScrollToBottom];
     


### PR DESCRIPTION
It's possible to use Finder to Get Info for MacIrssi.app and replace the icon with [something awesome](http://potential.deviantart.com/art/MacIrssi-Alternative-Icon-147762197).

However, `[NSApp applicationIconImage]` still returns the path to the bundled icon, so when the activity notification is being cleared and MacIrssi calls `[appController setIcon:defaultIcon]`, the user-specified icon is not used.

Passing `nil` instead of `defaultIcon` does the trick. [NSApplication setApplicationIconImage documentation](http://developer.apple.com/library/mac/#documentation/Cocoa/Reference/ApplicationKit/Classes/NSApplication_Class/Reference/Reference.html) agrees:

> To restore your application’s original icon, you pass nil to this method.

I've also added Debug menu items to test switching between the icons. To do so, I refactored `AppController -setIcon:` out into `-setNotificationIcon` and `-setDefaultIcon`.

It no longer seemed necessary to track `currentIcon` and `defaultIcon`, so I've removed these. This means there's no longer a guard around `setApplicationIconImage` checking if the icon is indeed changing, but that seemed like an unnecessary optimization.. unless there's something I don't know?

Cheers!
Paul
